### PR TITLE
Adjusts `pull.simple` components to act like polling components

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ It is up to you. I prefer yaml...
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat: "Hello World"
   push:
     - plugin: pnp.plugins.push.simple.Echo
@@ -245,7 +245,7 @@ Given the example ...
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
   push:
     plugin: pnp.plugins.push.fs.FileDump
     selector:
@@ -309,7 +309,7 @@ you can perform for each loops for pushes.
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat:
         - 1
         - 2
@@ -329,7 +329,7 @@ If you need the selector to augment your list, use a `push.simple.Nop` with `unw
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat:
         - 1
         - 2
@@ -534,7 +534,7 @@ Additional example:
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat: "Hello World"
   push:
     - plugin: pnp.plugins.push.simple.Echo
@@ -581,7 +581,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo

--- a/config/01_hello_world.yaml
+++ b/config/01_hello_world.yaml
@@ -8,7 +8,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat: "Hello World"
   push:
     - plugin: pnp.plugins.push.simple.Echo

--- a/config/02_multipush.yaml
+++ b/config/02_multipush.yaml
@@ -6,7 +6,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat: "Hello World"
   push:
     - plugin: pnp.plugins.push.simple.Echo

--- a/config/03_lambda_selector.yaml
+++ b/config/03_lambda_selector.yaml
@@ -3,7 +3,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat: "Hello World"
   push:
     - plugin: pnp.plugins.push.simple.Echo

--- a/config/03_selector.yaml
+++ b/config/03_selector.yaml
@@ -9,7 +9,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat: "Hello World"
   push:
     - plugin: pnp.plugins.push.simple.Echo

--- a/config/04_suppress.yaml
+++ b/config/04_suppress.yaml
@@ -8,7 +8,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
   push:
     - plugin: pnp.plugins.push.simple.Echo
       # variable suppress is basically a constant that tells the push not to execute

--- a/config/05_dependencies.yaml
+++ b/config/05_dependencies.yaml
@@ -11,7 +11,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat: "Hello World"
   push:
     - plugin: pnp.plugins.push.simple.Nop

--- a/config/06_complex.yaml
+++ b/config/06_complex.yaml
@@ -9,7 +9,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat: "Hello World"
   push:
     - plugin: pnp.plugins.push.simple.Nop

--- a/config/07_reference.yaml
+++ b/config/07_reference.yaml
@@ -10,7 +10,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - <<: *echo_plugin

--- a/config/08_envelope.yaml
+++ b/config/08_envelope.yaml
@@ -3,7 +3,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
   push:
     plugin: pnp.plugins.push.fs.FileDump
     selector:

--- a/config/engines/process.yaml
+++ b/config/engines/process.yaml
@@ -8,7 +8,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo

--- a/config/engines/sequential.yaml
+++ b/config/engines/sequential.yaml
@@ -7,7 +7,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Count
       args:
-        wait: 1
+        interval: 1s
         from_cnt: 1
         to_cnt: 4
     push:

--- a/config/engines/threading.yaml
+++ b/config/engines/threading.yaml
@@ -8,7 +8,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo

--- a/config/readme/01_hello_world.yaml
+++ b/config/readme/01_hello_world.yaml
@@ -2,7 +2,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat: "Hello World"
   push:
     - plugin: pnp.plugins.push.simple.Echo

--- a/config/readme/05_envelope.yaml
+++ b/config/readme/05_envelope.yaml
@@ -2,7 +2,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
   push:
     plugin: pnp.plugins.push.fs.FileDump
     selector:

--- a/config/readme/06_unwrapping.yaml
+++ b/config/readme/06_unwrapping.yaml
@@ -2,7 +2,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat:
         - 1
         - 2

--- a/config/readme/07_unwrapping_nop.yaml
+++ b/config/readme/07_unwrapping_nop.yaml
@@ -2,7 +2,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Repeat
     args:
-      wait: 1
+      interval: 1s
       repeat:
         - 1
         - 2

--- a/config/readme/08_udf.yaml
+++ b/config/readme/08_udf.yaml
@@ -17,7 +17,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo

--- a/config/readme/09_udf_throttle.yaml
+++ b/config/readme/09_udf_throttle.yaml
@@ -11,7 +11,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo

--- a/docs/engines/README.md
+++ b/docs/engines/README.md
@@ -37,7 +37,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Count
       args:
-        wait: 1
+        interval: 1s
         from_cnt: 1
         to_cnt: 4
     push:
@@ -62,7 +62,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo
@@ -86,7 +86,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo
@@ -109,7 +109,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo

--- a/docs/engines/async.yaml
+++ b/docs/engines/async.yaml
@@ -9,7 +9,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo

--- a/docs/engines/process.yaml
+++ b/docs/engines/process.yaml
@@ -10,7 +10,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo

--- a/docs/engines/sequential.yaml
+++ b/docs/engines/sequential.yaml
@@ -10,7 +10,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Count
       args:
-        wait: 1
+        interval: 1s
         from_cnt: 1
         to_cnt: 4
     push:

--- a/docs/engines/threading.yaml
+++ b/docs/engines/threading.yaml
@@ -10,7 +10,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
-        wait: 1
+        interval: 1s
         repeat: "Hello World"
     push:
       - plugin: pnp.plugins.push.simple.Echo

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1312,12 +1312,13 @@ __Examples__
 
 ### 1.18\. pnp.plugins.pull.simple.Count
 
-Emits every `wait` seconds a counting value which runs from `from_cnt` to `to_cnt`.
-If `to_cnt` is None the counter will count to infinity.
+Emits every `interval` seconds a counting value which runs from `from_cnt` to `to_cnt`.
+If `to_cnt` is None the counter will count to infinity (or more precise to sys.maxsize).
 
 __Arguments__
 
-- **wait (int)**: Wait the amount of seconds before emitting the next counter.
+- **interval (duration literal)**: Wait the amount of seconds before emitting the next counter.
+- **wait (int)**: DEPRECATED! Use `interval` instead.
 - **from_cnt (int)**: Starting value of the counter.
 - **to_cnt (int, optional)**: End value of the counter. If not passed set to "infinity" (precise: int.max).
 
@@ -1332,7 +1333,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
       to_cnt: 10
   push:
@@ -1383,11 +1384,12 @@ __Examples__
 
 ### 1.20\. pnp.plugins.pull.simple.Repeat
 
-Emits every `wait` seconds the same `repeat`.
+Emits every `interval` seconds the same `repeat`.
 
 __Arguments__
 
-- **wait (int)**: Wait the amount of seconds before emitting the next repeat.
+- **interval (duration literal)**: Wait the amount of seconds before emitting the next `repeat`.
+- **wait (int)**: DEPRECATED! Use `interval` instead.
 - **repeat (any)**: The object to emit.
 
 __Result__
@@ -1402,7 +1404,7 @@ __Examples__
     plugin: pnp.plugins.pull.simple.Repeat
     args:
       repeat: "Hello World"  # Repeats 'Hello World'
-      wait: 1  # Every second
+      interval: 1s  # Every second
   push:
     plugin: pnp.plugins.push.simple.Echo
 
@@ -1801,7 +1803,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 10
+      interval: 10s
   push:
     plugin: pnp.plugins.push.hass.Service
     selector:
@@ -1820,7 +1822,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 10
+      interval: 10s
   push:
     plugin: pnp.plugins.push.hass.Service
     selector:
@@ -1875,7 +1877,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 5
+      interval: 5s
   push:
     plugin: pnp.plugins.push.http.Call
     selector:
@@ -1904,7 +1906,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 5
+      interval: 5s
   push:
     plugin: pnp.plugins.push.http.Call
     args:
@@ -2172,7 +2174,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
   push:
     plugin: pnp.plugins.push.mqtt.Publish
     # Lets override the topic via envelope mechanism
@@ -2324,7 +2326,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
       to_cnt: 10
   push:
@@ -2371,7 +2373,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
   push:
     plugin: pnp.plugins.push.simple.Execute
@@ -2400,7 +2402,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
   push:
     plugin: pnp.plugins.push.simple.Execute
@@ -2451,7 +2453,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Count  # Let's count
       args:
-        wait: 1
+        interval: 1s
     push:
       - plugin: pnp.plugins.push.simple.Echo
         selector: "'START WAITING: {}'.format(payload)"
@@ -2615,7 +2617,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
         repeat: "Hello World"  # Repeats 'Hello World'
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         # Will only print the data when attribute azimuth of the sun component is above 200
@@ -2654,7 +2656,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
         repeat: "Hello World"  # Repeats 'Hello World'
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         selector:
@@ -2742,7 +2744,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Count
       args:
         from_cnt: 1
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         # Will memorize every uneven count

--- a/docs/plugins/pull/README.md
+++ b/docs/plugins/pull/README.md
@@ -1226,12 +1226,13 @@ __Examples__
 ```
 ## pnp.plugins.pull.simple.Count
 
-Emits every `wait` seconds a counting value which runs from `from_cnt` to `to_cnt`.
-If `to_cnt` is None the counter will count to infinity.
+Emits every `interval` seconds a counting value which runs from `from_cnt` to `to_cnt`.
+If `to_cnt` is None the counter will count to infinity (or more precise to sys.maxsize).
 
 __Arguments__
 
-- **wait (int)**: Wait the amount of seconds before emitting the next counter.
+- **interval (duration literal)**: Wait the amount of seconds before emitting the next counter.
+- **wait (int)**: DEPRECATED! Use `interval` instead.
 - **from_cnt (int)**: Starting value of the counter.
 - **to_cnt (int, optional)**: End value of the counter. If not passed set to "infinity" (precise: int.max).
 
@@ -1246,7 +1247,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
       to_cnt: 10
   push:
@@ -1293,11 +1294,12 @@ __Examples__
 ```
 ## pnp.plugins.pull.simple.Repeat
 
-Emits every `wait` seconds the same `repeat`.
+Emits every `interval` seconds the same `repeat`.
 
 __Arguments__
 
-- **wait (int)**: Wait the amount of seconds before emitting the next repeat.
+- **interval (duration literal)**: Wait the amount of seconds before emitting the next `repeat`.
+- **wait (int)**: DEPRECATED! Use `interval` instead.
 - **repeat (any)**: The object to emit.
 
 __Result__
@@ -1312,7 +1314,7 @@ __Examples__
     plugin: pnp.plugins.pull.simple.Repeat
     args:
       repeat: "Hello World"  # Repeats 'Hello World'
-      wait: 1  # Every second
+      interval: 1s  # Every second
   push:
     plugin: pnp.plugins.push.simple.Echo
 

--- a/docs/plugins/pull/simple.Count/example.yaml
+++ b/docs/plugins/pull/simple.Count/example.yaml
@@ -2,7 +2,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
       to_cnt: 10
   push:

--- a/docs/plugins/pull/simple.Count/index.md
+++ b/docs/plugins/pull/simple.Count/index.md
@@ -1,11 +1,12 @@
 # pnp.plugins.pull.simple.Count
 
-Emits every `wait` seconds a counting value which runs from `from_cnt` to `to_cnt`.
-If `to_cnt` is None the counter will count to infinity.
+Emits every `interval` seconds a counting value which runs from `from_cnt` to `to_cnt`.
+If `to_cnt` is None the counter will count to infinity (or more precise to sys.maxsize).
 
 __Arguments__
 
-- **wait (int)**: Wait the amount of seconds before emitting the next counter.
+- **interval (duration literal)**: Wait the amount of seconds before emitting the next counter.
+- **wait (int)**: DEPRECATED! Use `interval` instead.
 - **from_cnt (int)**: Starting value of the counter.
 - **to_cnt (int, optional)**: End value of the counter. If not passed set to "infinity" (precise: int.max).
 
@@ -20,7 +21,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
       to_cnt: 10
   push:

--- a/docs/plugins/pull/simple.Count/index.mdpp
+++ b/docs/plugins/pull/simple.Count/index.mdpp
@@ -1,11 +1,12 @@
 # pnp.plugins.pull.simple.Count
 
-Emits every `wait` seconds a counting value which runs from `from_cnt` to `to_cnt`.
-If `to_cnt` is None the counter will count to infinity.
+Emits every `interval` seconds a counting value which runs from `from_cnt` to `to_cnt`.
+If `to_cnt` is None the counter will count to infinity (or more precise to sys.maxsize).
 
 __Arguments__
 
-- **wait (int)**: Wait the amount of seconds before emitting the next counter.
+- **interval (duration literal)**: Wait the amount of seconds before emitting the next counter.
+- **wait (int)**: DEPRECATED! Use `interval` instead.
 - **from_cnt (int)**: Starting value of the counter.
 - **to_cnt (int, optional)**: End value of the counter. If not passed set to "infinity" (precise: int.max).
 

--- a/docs/plugins/pull/simple.Repeat/example.yaml
+++ b/docs/plugins/pull/simple.Repeat/example.yaml
@@ -3,6 +3,6 @@
     plugin: pnp.plugins.pull.simple.Repeat
     args:
       repeat: "Hello World"  # Repeats 'Hello World'
-      wait: 1  # Every second
+      interval: 1s  # Every second
   push:
     plugin: pnp.plugins.push.simple.Echo

--- a/docs/plugins/pull/simple.Repeat/index.md
+++ b/docs/plugins/pull/simple.Repeat/index.md
@@ -1,10 +1,11 @@
 # pnp.plugins.pull.simple.Repeat
 
-Emits every `wait` seconds the same `repeat`.
+Emits every `interval` seconds the same `repeat`.
 
 __Arguments__
 
-- **wait (int)**: Wait the amount of seconds before emitting the next repeat.
+- **interval (duration literal)**: Wait the amount of seconds before emitting the next `repeat`.
+- **wait (int)**: DEPRECATED! Use `interval` instead.
 - **repeat (any)**: The object to emit.
 
 __Result__
@@ -19,7 +20,7 @@ __Examples__
     plugin: pnp.plugins.pull.simple.Repeat
     args:
       repeat: "Hello World"  # Repeats 'Hello World'
-      wait: 1  # Every second
+      interval: 1s  # Every second
   push:
     plugin: pnp.plugins.push.simple.Echo
 

--- a/docs/plugins/pull/simple.Repeat/index.mdpp
+++ b/docs/plugins/pull/simple.Repeat/index.mdpp
@@ -1,10 +1,11 @@
 # pnp.plugins.pull.simple.Repeat
 
-Emits every `wait` seconds the same `repeat`.
+Emits every `interval` seconds the same `repeat`.
 
 __Arguments__
 
-- **wait (int)**: Wait the amount of seconds before emitting the next repeat.
+- **interval (duration literal)**: Wait the amount of seconds before emitting the next `repeat`.
+- **wait (int)**: DEPRECATED! Use `interval` instead.
 - **repeat (any)**: The object to emit.
 
 __Result__

--- a/docs/plugins/push/README.md
+++ b/docs/plugins/push/README.md
@@ -90,7 +90,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 10
+      interval: 10s
   push:
     plugin: pnp.plugins.push.hass.Service
     selector:
@@ -109,7 +109,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 10
+      interval: 10s
   push:
     plugin: pnp.plugins.push.hass.Service
     selector:
@@ -162,7 +162,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 5
+      interval: 5s
   push:
     plugin: pnp.plugins.push.http.Call
     selector:
@@ -191,7 +191,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 5
+      interval: 5s
   push:
     plugin: pnp.plugins.push.http.Call
     args:
@@ -451,7 +451,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
   push:
     plugin: pnp.plugins.push.mqtt.Publish
     # Lets override the topic via envelope mechanism
@@ -597,7 +597,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
       to_cnt: 10
   push:
@@ -642,7 +642,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
   push:
     plugin: pnp.plugins.push.simple.Execute
@@ -671,7 +671,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
   push:
     plugin: pnp.plugins.push.simple.Execute
@@ -720,7 +720,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Count  # Let's count
       args:
-        wait: 1
+        interval: 1s
     push:
       - plugin: pnp.plugins.push.simple.Echo
         selector: "'START WAITING: {}'.format(payload)"

--- a/docs/plugins/push/hass.Service/example.yaml
+++ b/docs/plugins/push/hass.Service/example.yaml
@@ -3,7 +3,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 10
+      interval: 10s
   push:
     plugin: pnp.plugins.push.hass.Service
     selector:

--- a/docs/plugins/push/hass.Service/example2.yaml
+++ b/docs/plugins/push/hass.Service/example2.yaml
@@ -3,7 +3,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 10
+      interval: 10s
   push:
     plugin: pnp.plugins.push.hass.Service
     selector:

--- a/docs/plugins/push/hass.Service/index.md
+++ b/docs/plugins/push/hass.Service/index.md
@@ -22,7 +22,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 10
+      interval: 10s
   push:
     plugin: pnp.plugins.push.hass.Service
     selector:
@@ -41,7 +41,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 10
+      interval: 10s
   push:
     plugin: pnp.plugins.push.hass.Service
     selector:

--- a/docs/plugins/push/http.Call/example1.yaml
+++ b/docs/plugins/push/http.Call/example1.yaml
@@ -4,7 +4,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 5
+      interval: 5s
   push:
     plugin: pnp.plugins.push.http.Call
     selector:

--- a/docs/plugins/push/http.Call/example2.yaml
+++ b/docs/plugins/push/http.Call/example2.yaml
@@ -4,7 +4,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 5
+      interval: 5s
   push:
     plugin: pnp.plugins.push.http.Call
     args:

--- a/docs/plugins/push/http.Call/index.md
+++ b/docs/plugins/push/http.Call/index.md
@@ -39,7 +39,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 5
+      interval: 5s
   push:
     plugin: pnp.plugins.push.http.Call
     selector:
@@ -68,7 +68,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 5
+      interval: 5s
   push:
     plugin: pnp.plugins.push.http.Call
     args:

--- a/docs/plugins/push/mqtt.Publish/example2.yaml
+++ b/docs/plugins/push/mqtt.Publish/example2.yaml
@@ -2,7 +2,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
   push:
     plugin: pnp.plugins.push.mqtt.Publish
     # Lets override the topic via envelope mechanism

--- a/docs/plugins/push/mqtt.Publish/index.md
+++ b/docs/plugins/push/mqtt.Publish/index.md
@@ -47,7 +47,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
   push:
     plugin: pnp.plugins.push.mqtt.Publish
     # Lets override the topic via envelope mechanism

--- a/docs/plugins/push/simple.Echo/example.yaml
+++ b/docs/plugins/push/simple.Echo/example.yaml
@@ -2,7 +2,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
       to_cnt: 10
   push:

--- a/docs/plugins/push/simple.Echo/index.md
+++ b/docs/plugins/push/simple.Echo/index.md
@@ -17,7 +17,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
       to_cnt: 10
   push:

--- a/docs/plugins/push/simple.Execute/example1.yaml
+++ b/docs/plugins/push/simple.Execute/example1.yaml
@@ -2,7 +2,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
   push:
     plugin: pnp.plugins.push.simple.Execute

--- a/docs/plugins/push/simple.Execute/example2.yaml
+++ b/docs/plugins/push/simple.Execute/example2.yaml
@@ -2,7 +2,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
   push:
     plugin: pnp.plugins.push.simple.Execute

--- a/docs/plugins/push/simple.Execute/example3.yaml
+++ b/docs/plugins/push/simple.Execute/example3.yaml
@@ -2,7 +2,7 @@
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
   push:
     plugin: pnp.plugins.push.simple.Execute

--- a/docs/plugins/push/simple.Execute/index.md
+++ b/docs/plugins/push/simple.Execute/index.md
@@ -36,7 +36,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
   push:
     plugin: pnp.plugins.push.simple.Execute
@@ -65,7 +65,7 @@ __Examples__
   pull:
     plugin: pnp.plugins.pull.simple.Count
     args:
-      wait: 1
+      interval: 1s
       from_cnt: 1
   push:
     plugin: pnp.plugins.push.simple.Execute

--- a/docs/plugins/push/simple.Wait/example.yaml
+++ b/docs/plugins/push/simple.Wait/example.yaml
@@ -7,7 +7,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Count  # Let's count
       args:
-        wait: 1
+        interval: 1s
     push:
       - plugin: pnp.plugins.push.simple.Echo
         selector: "'START WAITING: {}'.format(payload)"

--- a/docs/plugins/push/simple.Wait/index.md
+++ b/docs/plugins/push/simple.Wait/index.md
@@ -29,7 +29,7 @@ tasks:
     pull:
       plugin: pnp.plugins.pull.simple.Count  # Let's count
       args:
-        wait: 1
+        interval: 1s
     push:
       - plugin: pnp.plugins.push.simple.Echo
         selector: "'START WAITING: {}'.format(payload)"

--- a/docs/plugins/udf/README.md
+++ b/docs/plugins/udf/README.md
@@ -37,7 +37,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
         repeat: "Hello World"  # Repeats 'Hello World'
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         # Will only print the data when attribute azimuth of the sun component is above 200
@@ -74,7 +74,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
         repeat: "Hello World"  # Repeats 'Hello World'
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         selector:
@@ -158,7 +158,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Count
       args:
         from_cnt: 1
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         # Will memorize every uneven count

--- a/docs/plugins/udf/hass.State/example.yaml
+++ b/docs/plugins/udf/hass.State/example.yaml
@@ -11,7 +11,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
         repeat: "Hello World"  # Repeats 'Hello World'
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         # Will only print the data when attribute azimuth of the sun component is above 200

--- a/docs/plugins/udf/hass.State/index.md
+++ b/docs/plugins/udf/hass.State/index.md
@@ -35,7 +35,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
         repeat: "Hello World"  # Repeats 'Hello World'
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         # Will only print the data when attribute azimuth of the sun component is above 200

--- a/docs/plugins/udf/simple.Counter/example.yaml
+++ b/docs/plugins/udf/simple.Counter/example.yaml
@@ -10,7 +10,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
         repeat: "Hello World"  # Repeats 'Hello World'
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         selector:

--- a/docs/plugins/udf/simple.Counter/index.md
+++ b/docs/plugins/udf/simple.Counter/index.md
@@ -25,7 +25,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Repeat
       args:
         repeat: "Hello World"  # Repeats 'Hello World'
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         selector:

--- a/docs/plugins/udf/simple.Memory/example.yaml
+++ b/docs/plugins/udf/simple.Memory/example.yaml
@@ -9,7 +9,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Count
       args:
         from_cnt: 1
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         # Will memorize every uneven count

--- a/docs/plugins/udf/simple.Memory/index.md
+++ b/docs/plugins/udf/simple.Memory/index.md
@@ -30,7 +30,7 @@ tasks:
       plugin: pnp.plugins.pull.simple.Count
       args:
         from_cnt: 1
-        wait: 1  # Every second
+        interval: 1s  # Every second
     push:
       - plugin: pnp.plugins.push.simple.Echo
         # Will memorize every uneven count

--- a/pnp/typing.py
+++ b/pnp/typing.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Union, List, Callable, Optional
 from typing_extensions import Protocol
 
 AnyCallable = Callable[..., Any]
-DurationLiteral = Union[str, int]
+DurationLiteral = Union[str, int, float]
 Envelope = Dict[str, Any]
 Payload = Any  # pylint: disable=invalid-name
 SelectorExpression = Union[str, Dict[str, str], List[str]]

--- a/pnp/utils.py
+++ b/pnp/utils.py
@@ -604,6 +604,28 @@ def get_bytes(stream_or_file: Any) -> Union[bytes, str]:
     raise ValueError("Argument 'stream_or_file' is neither a stream nor a file")
 
 
+def is_real_float(candidate: Any) -> bool:
+    """
+    Checks if the given candidate is a real float. An integer will return False.
+
+    Examples:
+        >>> is_real_float(1.1)
+        True
+        >>> is_real_float(1.0)
+        False
+        >>> is_real_float(object())
+        False
+        >>> is_real_float(1)
+        False
+        >>> is_real_float("str")
+        False
+    """
+    try:
+        return not float(candidate).is_integer()
+    except (TypeError, ValueError):
+        return False
+
+
 def parse_duration_literal(literal: DurationLiteral) -> int:
     """
     Converts duration literals as '1m', '1h', and so on to an actual duration in seconds.
@@ -612,6 +634,8 @@ def parse_duration_literal(literal: DurationLiteral) -> int:
     Examples:
 
         >>> parse_duration_literal(60)  # Int will be interpreted as seconds
+        60
+        >>> parse_duration_literal(60.5)  # Float gets truncated
         60
         >>> parse_duration_literal('10')  # Any int convertible will be interpreted as seconds
         10
@@ -650,6 +674,33 @@ def parse_duration_literal(literal: DurationLiteral) -> int:
         if value is None or unit not in seconds_per_unit:
             raise TypeError("Interval '{}' is not a valid literal".format(literal))
         return value * seconds_per_unit[unit]
+
+
+def parse_duration_literal_float(literal: DurationLiteral) -> float:
+    """
+    Converts duration literals as '1m', '1h', and so on to an actual duration in seconds.
+    Supported are 's' (seconds), 'm' (minutes), 'h' (hours), 'd' (days) and 'w' (weeks).
+
+    Difference between `parse_duration_literal` and `parse_duration_literal_float` that
+    the `*_float` will return a float and therefore allow fractions
+
+    Examples:
+        >>> parse_duration_literal_float(60.5)  # Float will be preserved
+        60.5
+        >>> parse_duration_literal_float('20s')  # Seconds literal
+        20.0
+
+    Args:
+        literal: Literal to parse.
+
+    Returns:
+        Returns the converted literal's duration in seconds. If conversion is not possible
+        an exception is raised.
+    """
+    if is_real_float(literal):
+        return float(literal)
+
+    return float(parse_duration_literal(literal))
 
 
 def safe_get(dct: Dict[Any, Any], *keys: Any, default: Any = None) -> Any:

--- a/tests/plugins/pull/test_simple_count.py
+++ b/tests/plugins/pull/test_simple_count.py
@@ -9,12 +9,12 @@ def test_count_pull():
     def callback(plugin, payload):
         events.append(payload)
 
-    dut = Count(name='pytest', from_cnt=0, to_cnt=5, wait=0.1)
+    dut = Count(name='pytest', from_cnt=0, to_cnt=5, wait=0.001)
     runner = make_runner(dut, callback)
     with start_runner(runner):
-        time.sleep(1)
+        time.sleep(0.05)
 
-    assert events == [0, 1, 2, 3, 4]
+    assert events == [0, 1, 2, 3, 4, 5]
 
 
 def test_count_pull_infinity():
@@ -22,10 +22,23 @@ def test_count_pull_infinity():
     def callback(plugin, payload):
         events.append(payload)
 
-    dut = Count(name='pytest', from_cnt=0, to_cnt=None, wait=0.1)
+    dut = Count(name='pytest', from_cnt=0, to_cnt=None, wait=0.001)
     runner = make_runner(dut, callback)
     with start_runner(runner):
-        time.sleep(1)
+        time.sleep(0.01)
 
     expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     assert all([exp == actual for exp, actual in zip(expected, events)])
+
+
+def test_count_wait_compat():
+    dut = Count(name='pytest', wait=0.5)
+    assert dut.interval == 0.5
+    dut = Count(name='pytest', wait="1m")
+    assert dut.interval == 60
+    dut = Count(name='pytest', interval="1m")
+    assert dut.interval == 60
+    dut = Count(name='pytest', wait="2m", interval="1m")
+    assert dut.interval == 60
+    dut = Count(name='pytest')
+    assert dut.interval == 5

--- a/tests/plugins/pull/test_simple_repeat.py
+++ b/tests/plugins/pull/test_simple_repeat.py
@@ -9,10 +9,23 @@ def test_repeat_pull():
     def callback(plugin, payload):
         events.append(payload)
 
-    dut = Repeat(name='pytest', repeat="Hello World", wait=0.1)
+    dut = Repeat(name='pytest', repeat="Hello World", wait=0.001)
     runner = make_runner(dut, callback)
     with start_runner(runner):
-        time.sleep(1)
+        time.sleep(0.01)
 
     assert len(events) >= 5
     assert all([p == "Hello World" for p in events])
+
+
+def test_repeat_wait_compat():
+    dut = Repeat(name='pytest', wait=0.5, repeat="Hello World")
+    assert dut.interval == 0.5
+    dut = Repeat(name='pytest', wait="1m", repeat="Hello World")
+    assert dut.interval == 60
+    dut = Repeat(name='pytest', interval="1m", repeat="Hello World")
+    assert dut.interval == 60
+    dut = Repeat(name='pytest', wait="2m", interval="1m", repeat="Hello World")
+    assert dut.interval == 60
+    dut = Repeat(name='pytest', repeat="Hello World")
+    assert dut.interval == 5

--- a/tests/plugins/test_load_plugin.py
+++ b/tests/plugins/test_load_plugin.py
@@ -9,7 +9,7 @@ def test_load_plugin():
     plugin = load_plugin("pnp.plugins.pull.simple.Repeat", PullBase, name='pytest', repeat="Hello World", wait=1)
     assert plugin is not None
     assert isinstance(plugin, Repeat)
-    assert str(plugin) == "Repeat(name='pytest', repeat='Hello World', wait=1.0)"
+    assert str(plugin) == "Repeat(interval=1.0, name='pytest', repeat='Hello World')"
 
 
 def test_load_plugin_with_invalid_plugins():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,7 +19,7 @@ def test_mk_pull():
     assert isinstance(res.instance, Repeat)
     assert res.instance.name == 'pytest_pull'
     assert res.instance.repeat == 'hello'
-    assert res.instance.wait == 1.0
+    assert res.instance.interval == 1.0
 
 
 def test_mk_push():


### PR DESCRIPTION
But we cannot simply convert them because they accept floats for the interval, but
the polling component does not support that. So we try to mimic
the behavior.as best as we can.

* Allows floats for parse_duration_literal
* Adds interval argument for components
* Adds duration literal parsing of interval/wait argument