### PR TITLE
Migrates Dockerfile from stretch to buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Notice: Keep this file in sync with Dockerfile.arm32v7
 #
 
-FROM python:3.7-slim-stretch
+FROM python:3.7-slim-buster
 
 LABEL maintainer="Dennis Muth <d.muth@gmx.net>"
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -2,7 +2,7 @@
 # Notice: Keep this file in sync with Dockerfile
 #
 
-FROM arm32v7/python:3.7-slim-stretch
+FROM arm32v7/python:3.7-slim-buster
 COPY qemu-arm-static /usr/bin
 
 LABEL maintainer="Dennis Muth <d.muth@gmx.net>"
@@ -55,10 +55,5 @@ RUN poetry build && \
         --no-cache-dir \
         --extra-index-url https://www.piwheels.org/simple \
         "dist/$(poetry version | tr ' ' '-')-py3-none-any.whl"
-
-# Due to some errors with the wheel file from piwheels (segfault)
-# we have to remove uvloop
-# We do not need to reinstall because we do not use uvloop
-RUN pip3 uninstall --yes uvloop
 
 CMD ["pnp", "/config/config.yaml"]

--- a/scripts/dev-container
+++ b/scripts/dev-container
@@ -19,11 +19,11 @@ function run() {
 
     SOURCE=`abspath "${PACKAGE}/.."`
 
-    distro=slim
+    distro=buster
 
-    if [ ${VERSION} == "3.8" -o ${VERSION} == "3.9" ]; then
-        distro=buster
-    fi
+#    if [ ${VERSION} == "3.8" -o ${VERSION} == "3.9" ]; then
+#        distro=buster
+#    fi
 
     echo "Ubuntu Distribution is: ${distro}"
 


### PR DESCRIPTION
As a nice side-effect uvloop is running fine on buster.
So the previously experienced segfault is gone.