### PR TITLE
Adds archive_name argument to push.fs.Zipper

### DIFF
--- a/docs/source/code-samples/plugins/push/fs.Zipper/example_backup.yaml
+++ b/docs/source/code-samples/plugins/push/fs.Zipper/example_backup.yaml
@@ -1,0 +1,16 @@
+tasks:
+  - name: zipper
+    pull:
+      plugin: pnp.plugins.pull.simple.Cron
+      args:
+        expressions:
+          - "*/1 * * * * /tmp/backup_folder"
+    push:
+      plugin: pnp.plugins.push.fs.Zipper
+      args:
+        out_path: "{{env::BACKUP_DIR}}"
+      selector:
+        archive_name: "lambda payload: '{}_{}'.format(now().isoformat(), 'backup.zip')"
+        data: "lambda payload: payload"
+      deps:
+        plugin: pnp.plugins.push.simple.Echo

--- a/docs/source/plugins/push/fs.Zipper.rst
+++ b/docs/source/plugins/push/fs.Zipper.rst
@@ -29,13 +29,21 @@ the absolute path to the created zip file.
 
 **Arguments**
 
-+----------+------+------+---------+-----+-------------------------------------------------------------------------------------------------------------------------------------------------+
-| name     | type | opt. | default | env | description                                                                                                                                     |
-+==========+======+======+=========+=====+=================================================================================================================================================+
-| source   | str  | yes  | n/a     | yes | Specifies the source directory or file to zip. If not passed the source can be specified by the envelope at runtime.                            |
-+----------+------+------+---------+-----+-------------------------------------------------------------------------------------------------------------------------------------------------+
-| out_path | str  | yes  | tmp     | no  | Specifies the path to the general output path where all target zip files should be generated. If not passed the systems temp directory is used. |
-+----------+------+------+---------+-----+-------------------------------------------------------------------------------------------------------------------------------------------------+
++--------------+------+------+---------+-----+-------------------------------------------------------------------------------------------------------------------------------------------------+
+| name         | type | opt. | default | env | description                                                                                                                                     |
++==============+======+======+=========+=====+=================================================================================================================================================+
+| source       | str  | yes  | n/a     | yes | Specifies the source directory or file to zip. If not passed the source can be specified by the envelope at runtime.                            |
++--------------+------+------+---------+-----+-------------------------------------------------------------------------------------------------------------------------------------------------+
+| out_path     | str  | yes  | tmp     | no  | Specifies the path to the general output path where all target zip files should be generated. If not passed the systems temp directory is used. |
++--------------+------+------+---------+-----+-------------------------------------------------------------------------------------------------------------------------------------------------+
+| archive_name | str  | yes  | below   | yes | Specifies the path to the general output path where all target zip files should be generated. If not passed the systems temp directory is used. |
++--------------+------+------+---------+-----+-------------------------------------------------------------------------------------------------------------------------------------------------+
+
+The default of ``archive_name`` will be either the original file name (if you zip a single file)
+resp. the name of the zipped directory (if you zip a directory).
+In both cases the extension ``.zip`` will be added.
+If you do not want an extension, you have to provide the ``archive_name``.
+
 
 **Result**
 
@@ -44,4 +52,10 @@ Will return an absolute path to the zip file created.
 **Example**
 
 .. literalinclude:: ../code-samples/plugins/push/fs.Zipper/example.yaml
+   :language: YAML
+
+The next example is useful for dynamically adjusting the archive name to generate
+unique names for storing multiple backups:
+
+.. literalinclude:: ../code-samples/plugins/push/fs.Zipper/example_backup.yaml
    :language: YAML

--- a/tests/plugins/push/test_fs_zipper.py
+++ b/tests/plugins/push/test_fs_zipper.py
@@ -39,3 +39,21 @@ def test_zipper_push_payload_file():
         zip_file_name = dut.push(path)
         assert zip_file_name == os.path.join(tmpdir, '1' + '.zip')
         assert set(ZipFile(zip_file_name).namelist()) == {'1'}
+
+
+def test_zipper_push_archive_name():
+    path = os.path.join(os.path.dirname(__file__), '../../resources/zipping/testdir')
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dut = Zipper(name='pytest', out_path=tmpdir, archive_name='foo.zip')
+        zip_file_name = dut.push(path)
+        assert zip_file_name == os.path.join(tmpdir, 'foo' + '.zip')
+        assert set(ZipFile(zip_file_name).namelist()) == {'1', '2/2'}
+
+
+def test_zipper_push_archive_name_override():
+    path = os.path.join(os.path.dirname(__file__), '../../resources/zipping/testdir')
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dut = Zipper(name='pytest', out_path=tmpdir)
+        zip_file_name = dut.push({'data': path, 'archive_name': 'foo.zip'})
+        assert zip_file_name == os.path.join(tmpdir, 'foo' + '.zip')
+        assert set(ZipFile(zip_file_name).namelist()) == {'1', '2/2'}


### PR DESCRIPTION
archive_name allows to control the name of the resulting zip archive.
It is useful for tasks where you want to change the archive name
at runtime (like adding a date to it).
See the examples on how to do it